### PR TITLE
Removed keyword `type` from export list for compatability with GHC 7.4.*

### DIFF
--- a/src/Data/Profunctor.hs
+++ b/src/Data/Profunctor.hs
@@ -34,7 +34,7 @@ module Data.Profunctor
   , WrappedArrow(..)
   , Forget(..)
 #ifndef HLINT
-  , type (:->)
+  , (:->)
 #endif
   ) where
 


### PR DESCRIPTION
Hi, I just removed the keyword `type` from the export list to be able to build the library again with GHC 7.4.\* (tested with 7.4.2). I suppose this slipped through at the last commit.
