### PR TITLE
add procomposed' using a Semigroupoid

### DIFF
--- a/profunctors.cabal
+++ b/profunctors.cabal
@@ -35,7 +35,8 @@ library
     contravariant       >= 1     && < 2,
     distributive        >= 0.4.4 && < 1,
     tagged              >= 0.4.4 && < 1,
-    transformers        >= 0.2   && < 0.5
+    transformers        >= 0.2   && < 0.5,
+    semigroupoids       >= 5     && < 6
 
   exposed-modules:
     Data.Profunctor

--- a/src/Data/Profunctor/Composition.hs
+++ b/src/Data/Profunctor/Composition.hs
@@ -23,7 +23,7 @@ module Data.Profunctor.Composition
   (
   -- * Profunctor Composition
     Procompose(..)
-  , procomposed
+  , procomposed, procomposed'
   -- * Unitors and Associator
   , idl
   , idr
@@ -48,6 +48,7 @@ import Data.Profunctor.Monad
 import Data.Profunctor.Rep
 import Data.Profunctor.Sieve
 import Data.Profunctor.Unsafe
+import Data.Semigroupoid
 import Prelude hiding ((.),id)
 
 type Iso s t a b = forall p f. (Profunctor p, Functor f) => p a (f b) -> p s (f t)
@@ -74,6 +75,10 @@ instance Category p => ProfunctorMonad (Procompose p) where
 procomposed :: Category p => Procompose p p a b -> p a b
 procomposed (Procompose pxc pdx) = pxc . pdx
 {-# INLINE procomposed #-}
+
+procomposed' :: Semigroupoid p => Procompose p p a b -> p a b
+procomposed' (Procompose pxc pdx) = pxc `o` pdx
+{-# INLINE procomposed' #-}
 
 instance (Profunctor p, Profunctor q) => Profunctor (Procompose p q) where
   dimap l r (Procompose f g) = Procompose (rmap r f) (lmap l g)


### PR DESCRIPTION
`procomposed` requires the profunctor to be a category, although it is only using composition, not the identity. This patch adds a `procomposed'` which is relaxing the constraint to only require a semigroupoid.