### PR TITLE
using Data.Coerce needs to be trusted

### DIFF
--- a/src/Data/Profunctor.hs
+++ b/src/Data/Profunctor.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702 && __GLASGOW_HASKELL__ < 708
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/src/Data/Profunctor/Traversing.hs
+++ b/src/Data/Profunctor/Traversing.hs
@@ -90,7 +90,7 @@ class (Choice p, Strong p) => Traversing p where
   wander :: (forall f. Applicative f => (a -> f b) -> s -> f t) -> p a b -> p s t
   wander f pab = dimap (\s -> Baz $ \afb -> f afb s) sold (traverse' pab)
 
-#if __GLASGOW_HASKELL__ >= 706
+#if __GLASGOW_HASKELL__ >= 708
   {-# MINIMAL wander | traverse' #-}
 #endif
 

--- a/src/Data/Profunctor/Types.hs
+++ b/src/Data/Profunctor/Types.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-#if __GLASGOW_HASKELL__ >= 704 && __GLASGOW_HASKELL__ < 708
+#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
 #endif
 


### PR DESCRIPTION
`Data.Profunctor.Types` is not inferred safe because it uses `Data.Coerce`, so mark it trustworthy.
