### PR TITLE
Fix unsafeCoerce typo in Yoneda.

### DIFF
--- a/src/Data/Profunctor/Yoneda.hs
+++ b/src/Data/Profunctor/Yoneda.hs
@@ -185,7 +185,7 @@ instance Profunctor (Coyoneda p) where
 #else
   p .# _ = unsafeCoerce p
   {-# INLINE (.#) #-}
-  (#.) _ = unsafecoerce
+  (#.) _ = unsafeCoerce
   {-# INLINE (#.) #-}
 #endif
 

--- a/src/Data/Profunctor/Yoneda.hs
+++ b/src/Data/Profunctor/Yoneda.hs
@@ -75,7 +75,7 @@ instance Profunctor (Yoneda p) where
 #else
   p .# _ = unsafeCoerce p
   {-# INLINE (.#) #-}
-  (#.) _ = unsafeCoerce
+  _ #. p = unsafeCoerce p
   {-# INLINE (#.) #-}
 #endif
 
@@ -185,7 +185,7 @@ instance Profunctor (Coyoneda p) where
 #else
   p .# _ = unsafeCoerce p
   {-# INLINE (.#) #-}
-  (#.) _ = unsafeCoerce
+  _ #. p = unsafeCoerce p
   {-# INLINE (#.) #-}
 #endif
 

--- a/src/Data/Profunctor/Yoneda.hs
+++ b/src/Data/Profunctor/Yoneda.hs
@@ -75,7 +75,7 @@ instance Profunctor (Yoneda p) where
 #else
   p .# _ = unsafeCoerce p
   {-# INLINE (.#) #-}
-  (#.) _ = unsafecoerce
+  (#.) _ = unsafeCoerce
   {-# INLINE (#.) #-}
 #endif
 


### PR DESCRIPTION
Looks like `unsafeCoerce` was typo'd as `unsafecoerce`.