### PR TITLE
Correct haddock markup in laws

### DIFF
--- a/src/Data/Profunctor/Adjunction.hs
+++ b/src/Data/Profunctor/Adjunction.hs
@@ -21,7 +21,7 @@ import Data.Profunctor.Monad
 --
 -- @
 -- 'unit' '.' 'counit' ≡ 'id'
--- 'couint' '.' 'unit' ≡ 'id'
+-- 'counit' '.' 'unit' ≡ 'id'
 -- @
 class (ProfunctorFunctor f, ProfunctorFunctor u) => ProfunctorAdjunction f u | f -> u, u -> f where
   unit   :: Profunctor p => p :-> u (f p)

--- a/src/Data/Profunctor/Choice.hs
+++ b/src/Data/Profunctor/Choice.hs
@@ -64,18 +64,20 @@ class Profunctor p => Choice p where
   -- | Laws:
   --
   -- @
-  -- 'left'' ≡ 'dimap' ('either' 'Right' 'Left') ('either' 'Right' 'Left') '.' 'right''
+  -- 'left'' ≡ 'dimap' swapE swapE '.' 'right'' where
+  --   swapE :: 'Either' a b -> 'Either' b a
+  --   swapE = 'either' 'Right' 'Left'
   -- 'rmap' 'Left' ≡ 'lmap' 'Left' '.' 'left''
   -- 'lmap' ('right' f) '.' 'left'' ≡ 'rmap' ('right' f) '.' 'left''
-  -- 'left'' '.' 'left'' ≡ 'dimap' assoc unassoc '.' 'left'' where
-  --   assoc :: 'Either' ('Either' a b) c -> 'Either' a ('Either' b c)
-  --   assoc ('Left' ('Left' a)) = 'Left' a
-  --   assoc ('Left' ('Right' b)) = 'Right' ('Left' b)
-  --   assoc ('Right' c) = 'Right' ('Right' c)
-  --   unassoc :: 'Either' a ('Either' b c) -> 'Either' ('Either' a b) c
-  --   unassoc ('Left' a) = 'Left' ('Left' a)
-  --   unassoc ('Right' ('Left' b) = 'Left' ('Right' b)
-  --   unassoc ('Right' ('Right' c)) = 'Right' c)
+  -- 'left'' '.' 'left'' ≡ 'dimap' assocE unassocE '.' 'left'' where
+  --   assocE :: 'Either' ('Either' a b) c -> 'Either' a ('Either' b c)
+  --   assocE ('Left' ('Left' a)) = 'Left' a
+  --   assocE ('Left' ('Right' b)) = 'Right' ('Left' b)
+  --   assocE ('Right' c) = 'Right' ('Right' c)
+  --   unassocE :: 'Either' a ('Either' b c) -> 'Either' ('Either' a b) c
+  --   unassocE ('Left' a) = 'Left' ('Left' a)
+  --   unassocE ('Right' ('Left' b) = 'Left' ('Right' b)
+  --   unassocE ('Right' ('Right' c)) = 'Right' c)
   -- @
   left'  :: p a b -> p (Either a c) (Either b c)
   left' =  dimap (either Right Left) (either Right Left) . right'
@@ -83,18 +85,20 @@ class Profunctor p => Choice p where
   -- | Laws:
   --
   -- @
-  -- 'right'' ≡ 'dimap' ('either' 'Right' 'Left') ('either' 'Right' 'Left') '.' 'left''
+  -- 'right'' ≡ 'dimap' swapE swapE '.' 'left'' where
+  --   swapE :: 'Either' a b -> 'Either' b a
+  --   swapE = 'either' 'Right' 'Left'
   -- 'rmap' 'Right' ≡ 'lmap' 'Right' '.' 'right''
   -- 'lmap' ('left' f) '.' 'right'' ≡ 'rmap' ('left' f) '.' 'right''
-  -- 'right'' '.' 'right'' ≡ 'dimap' unassoc assoc '.' 'right'' where
-  --   assoc :: 'Either' ('Either' a b) c -> 'Either' a ('Either' b c)
-  --   assoc ('Left' ('Left' a)) = 'Left' a
-  --   assoc ('Left' ('Right' b)) = 'Right' ('Left' b)
-  --   assoc ('Right' c) = 'Right' ('Right' c)
-  --   unassoc :: 'Either' a ('Either' b c) -> 'Either' ('Either' a b) c
-  --   unassoc ('Left' a) = 'Left' ('Left' a)
-  --   unassoc ('Right' ('Left' b) = 'Left' ('Right' b)
-  --   unassoc ('Right' ('Right' c)) = 'Right' c)
+  -- 'right'' '.' 'right'' ≡ 'dimap' unassocE assocE '.' 'right'' where
+  --   assocE :: 'Either' ('Either' a b) c -> 'Either' a ('Either' b c)
+  --   assocE ('Left' ('Left' a)) = 'Left' a
+  --   assocE ('Left' ('Right' b)) = 'Right' ('Left' b)
+  --   assocE ('Right' c) = 'Right' ('Right' c)
+  --   unassocE :: 'Either' a ('Either' b c) -> 'Either' ('Either' a b) c
+  --   unassocE ('Left' a) = 'Left' ('Left' a)
+  --   unassocE ('Right' ('Left' b) = 'Left' ('Right' b)
+  --   unassocE ('Right' ('Right' c)) = 'Right' c)
   -- @
   right' :: p a b -> p (Either c a) (Either c b)
   right' =  dimap (either Right Left) (either Right Left) . left'
@@ -293,18 +297,20 @@ class Profunctor p => Cochoice p where
   -- | Laws:
   --
   -- @
-  -- 'unleft' ≡ 'unright' '.' 'dimap' ('either' 'Right' 'Left') ('either' 'Right' 'Left')
-  -- 'rmap' ('either' 'id' 'absurd') ≡ 'unleft' . 'lmap' ('either' 'id' 'absurd')
-  -- 'unfirst' . 'rmap' ('second' f) ≡ 'unfirst' . 'lmap' ('second' f)
-  -- 'unleft' '.' 'unleft' ≡ 'unleft' . 'dimap' assoc unassoc where
-  --   assoc :: 'Either' ('Either' a b) c -> 'Either' a ('Either' b c)
-  --   assoc ('Left' ('Left' a)) = 'Left' a
-  --   assoc ('Left' ('Right' b)) = 'Right' ('Left' b)
-  --   assoc ('Right' c) = 'Right' ('Right' c)
-  --   unassoc :: 'Either' a ('Either' b c) -> 'Either' ('Either' a b) c
-  --   unassoc ('Left' a) = 'Left' ('Left' a)
-  --   unassoc ('Right' ('Left' b) = 'Left' ('Right' b)
-  --   unassoc ('Right' ('Right' c)) = 'Right' c)
+  -- 'unleft' ≡ 'unright' '.' 'dimap' swapE swapE where
+  --   swapE :: 'Either' a b -> 'Either' b a
+  --   swapE = 'either' 'Right' 'Left'
+  -- 'rmap' ('either' 'id' 'absurd') ≡ 'unleft' '.' 'lmap' ('either' 'id' 'absurd')
+  -- 'unfirst' '.' 'rmap' ('second' f) ≡ 'unfirst' '.' 'lmap' ('second' f)
+  -- 'unleft' '.' 'unleft' ≡ 'unleft' '.' 'dimap' assocE unassocE where
+  --   assocE :: 'Either' ('Either' a b) c -> 'Either' a ('Either' b c)
+  --   assocE ('Left' ('Left' a)) = 'Left' a
+  --   assocE ('Left' ('Right' b)) = 'Right' ('Left' b)
+  --   assocE ('Right' c) = 'Right' ('Right' c)
+  --   unassocE :: 'Either' a ('Either' b c) -> 'Either' ('Either' a b) c
+  --   unassocE ('Left' a) = 'Left' ('Left' a)
+  --   unassocE ('Right' ('Left' b) = 'Left' ('Right' b)
+  --   unassocE ('Right' ('Right' c)) = 'Right' c)
   -- @
   unleft  :: p (Either a d) (Either b d) -> p a b
   unleft = unright . dimap (either Right Left) (either Right Left)
@@ -312,18 +318,20 @@ class Profunctor p => Cochoice p where
   -- | Laws:
   --
   -- @
-  -- 'unright' ≡ 'unleft' '.' 'dimap' ('either' 'Right' 'Left') ('either' 'Right' 'Left')
-  -- 'rmap' ('either' 'absurd' 'id') ≡ 'unright' . 'lmap' ('either' 'absurd' 'id')
-  -- 'unsecond' . 'rmap' ('first' f) ≡ 'unsecond' . 'lmap' ('first' f)
-  -- 'unright' '.' 'unright' ≡ 'unright' . 'dimap' unassoc assoc where
-  --   assoc :: 'Either' ('Either' a b) c -> 'Either' a ('Either' b c)
-  --   assoc ('Left' ('Left' a)) = 'Left' a
-  --   assoc ('Left' ('Right' b)) = 'Right' ('Left' b)
-  --   assoc ('Right' c) = 'Right' ('Right' c)
-  --   unassoc :: 'Either' a ('Either' b c) -> 'Either' ('Either' a b) c
-  --   unassoc ('Left' a) = 'Left' ('Left' a)
-  --   unassoc ('Right' ('Left' b) = 'Left' ('Right' b)
-  --   unassoc ('Right' ('Right' c)) = 'Right' c)
+  -- 'unright' ≡ 'unleft' '.' 'dimap' swapE swapE where
+  --   swapE :: 'Either' a b -> 'Either' b a
+  --   swapE = 'either' 'Right' 'Left'
+  -- 'rmap' ('either' 'absurd' 'id') ≡ 'unright' '.' 'lmap' ('either' 'absurd' 'id')
+  -- 'unsecond' '.' 'rmap' ('first' f) ≡ 'unsecond' '.' 'lmap' ('first' f)
+  -- 'unright' '.' 'unright' ≡ 'unright' '.' 'dimap' unassocE assocE where
+  --   assocE :: 'Either' ('Either' a b) c -> 'Either' a ('Either' b c)
+  --   assocE ('Left' ('Left' a)) = 'Left' a
+  --   assocE ('Left' ('Right' b)) = 'Right' ('Left' b)
+  --   assocE ('Right' c) = 'Right' ('Right' c)
+  --   unassocE :: 'Either' a ('Either' b c) -> 'Either' ('Either' a b) c
+  --   unassocE ('Left' a) = 'Left' ('Left' a)
+  --   unassocE ('Right' ('Left' b) = 'Left' ('Right' b)
+  --   unassocE ('Right' ('Right' c)) = 'Right' c)
   -- @
   unright :: p (Either d a) (Either d b) -> p a b
   unright = unleft . dimap (either Right Left) (either Right Left)

--- a/src/Data/Profunctor/Closed.hs
+++ b/src/Data/Profunctor/Closed.hs
@@ -55,7 +55,7 @@ class Profunctor p => Closed p where
   -- | Laws:
   --
   -- @
-  -- 'lmap' ('.' f) '.' 'closed' ≡ 'rmap' ('.' f) . 'closed'
+  -- 'lmap' ('.' f) '.' 'closed' ≡ 'rmap' ('.' f) '.' 'closed'
   -- 'closed' '.' 'closed' ≡ 'dimap' 'uncurry' 'curry' '.' 'closed'
   -- 'dimap' 'const' ('$'()) '.' 'closed' ≡ 'id'
   -- @

--- a/src/Data/Profunctor/Mapping.hs
+++ b/src/Data/Profunctor/Mapping.hs
@@ -29,7 +29,7 @@ class (Traversing p, Closed p) => Mapping p where
   -- | Laws:
   --
   -- @
-  -- 'map'' '.' 'rmap' f ≡ 'rmap' ('fmap' f) . 'map''
+  -- 'map'' '.' 'rmap' f ≡ 'rmap' ('fmap' f) '.' 'map''
   -- 'map'' '.' 'map'' ≡ 'dimap' 'Data.Functor.Compose.Compose' 'Data.Functor.Compose.getCompose' '.' 'map''
   -- 'dimap' 'Data.Functor.Identity.Identity' 'Data.Functor.Identity.runIdentity' '.' 'map'' ≡ 'id'
   -- @

--- a/src/Data/Profunctor/Monad.hs
+++ b/src/Data/Profunctor/Monad.hs
@@ -23,7 +23,7 @@ class ProfunctorFunctor t where
   -- | Laws:
   --
   -- @
-  -- 'promap' f . 'promap' g ≡ 'promap' (f '.' g)
+  -- 'promap' f '.' 'promap' g ≡ 'promap' (f '.' g)
   -- 'promap' 'id' ≡ 'id'
   -- @
   promap    :: Profunctor p => (p :-> q) -> t p :-> t q
@@ -68,7 +68,7 @@ instance ProfunctorMonad (Sum p) where
 -- @
 -- 'proextract' '.' 'promap' f ≡ f '.' 'proextract'
 -- 'proextract' '.' 'produplicate' ≡ 'id'
--- 'promap' 'proextract' . 'produplicate' ≡ 'id'
+-- 'promap' 'proextract' '.' 'produplicate' ≡ 'id'
 -- 'produplicate' '.' 'produplicate' ≡ 'promap' 'produplicate' '.' 'produplicate'
 -- @
 class ProfunctorFunctor t => ProfunctorComonad t where

--- a/src/Data/Profunctor/Strong.hs
+++ b/src/Data/Profunctor/Strong.hs
@@ -70,7 +70,7 @@ class Profunctor p => Strong p where
   -- | Laws:
   --
   -- @
-  -- 'first' ≡ 'dimap' 'swap' 'swap' '.' 'second''
+  -- 'first'' ≡ 'dimap' 'swap' 'swap' '.' 'second''
   -- 'lmap' 'fst' ≡ 'rmap' 'fst' '.' 'first''
   -- 'lmap' ('second' f) '.' 'first'' ≡ 'rmap' ('second' f) '.' 'first'
   -- 'first'' '.' 'first'' ≡ 'dimap' assoc unassoc '.' 'first'' where
@@ -83,7 +83,7 @@ class Profunctor p => Strong p where
   -- | Laws:
   --
   -- @
-  -- second' ≡ 'dimap' 'swap' 'swap' . 'first''
+  -- 'second'' ≡ 'dimap' 'swap' 'swap' '.' 'first''
   -- 'lmap' 'snd' ≡ 'rmap' 'snd' '.' 'second''
   -- 'lmap' ('first' f) '.' 'second'' ≡ 'rmap' ('first' f) '.' 'second''
   -- 'second'' '.' 'second'' ≡ 'dimap' unassoc assoc '.' 'second'' where
@@ -320,7 +320,7 @@ class Profunctor p => Costrong p where
   -- 'unfirst' ≡ 'unsecond' '.' 'dimap' 'swap' 'swap'
   -- 'lmap' (,()) ≡ 'unfirst' '.' 'rmap' (,())
   -- 'unfirst' '.' 'lmap' ('second' f) ≡ 'unfirst' '.' 'rmap' ('second' f)
-  -- 'unfirst' '.' 'unfirst' = 'unfirst' . 'dimap' assoc unassoc where
+  -- 'unfirst' '.' 'unfirst' = 'unfirst' '.' 'dimap' assoc unassoc where
   --   assoc ((a,b),c) = (a,(b,c))
   --   unassoc (a,(b,c)) = ((a,b),c)
   -- @
@@ -333,7 +333,7 @@ class Profunctor p => Costrong p where
   -- 'unsecond' ≡ 'unfirst' '.' 'dimap' 'swap' 'swap'
   -- 'lmap' ((),) ≡ 'unsecond' '.' 'rmap' ((),)
   -- 'unsecond' '.' 'lmap' ('first' f) ≡ 'unsecond' '.' 'rmap' ('first' f)
-  -- 'unsecond' '.' 'unsecond' = 'unsecond' . 'dimap' unassoc assoc where
+  -- 'unsecond' '.' 'unsecond' = 'unsecond' '.' 'dimap' unassoc assoc where
   --   assoc ((a,b),c) = (a,(b,c))
   --   unassoc (a,(b,c)) = ((a,b),c)
   -- @

--- a/src/Data/Profunctor/Traversing.hs
+++ b/src/Data/Profunctor/Traversing.hs
@@ -88,7 +88,7 @@ class (Choice p, Strong p) => Traversing p where
   --
   -- @
   -- 'traverse'' ≡ 'wander' 'traverse'
-  -- 'traverse'' '.' 'rmap' f ≡ 'rmap' ('fmap' f) . 'traverse''
+  -- 'traverse'' '.' 'rmap' f ≡ 'rmap' ('fmap' f) '.' 'traverse''
   -- 'traverse'' '.' 'traverse'' ≡ 'dimap' 'Compose' 'getCompose' '.' 'traverse''
   -- 'dimap' 'Identity' 'runIdentity' '.' 'traverse'' ≡ 'id'
   -- @


### PR DESCRIPTION
I took right to introduce `swapE` and rename `Either` variants of `assoc`&`unassoc` to `assocE`&`unassocE`. I think, that would cause less confusion