### PR TITLE
Add changelog entry for safe Haskell change

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -5,6 +5,7 @@ HEAD
 * Add `dimapTraversing`, `lmapTraversing`, and `rmapTraversing` to `Data.Profunctor.Traversing`
 * Add documentation stating the laws for various profunctors.
 * Introduce the `Data.Profunctor.Yoneda` module.
+* Mark `Data.Profunctor.Types` trustworthy. Note that the module effectively reexports`Data.Coerce.coerce`, overriding its unsafe status in `base`.
 
 5.2
 ---


### PR DESCRIPTION
This won't affect many people, but the effective safe reexport of `Data.Coerce.coerce` seems worth noting nevertheless.