### PR TITLE
Adapt to the Semigroup–Monoid Proposal

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+next
+----
+* Add `Semigroup` instances for `Closure` and `Tambara`
+
 5.2.1
 -----
 * Allow `base-orphans-0.6`.

--- a/profunctors.cabal
+++ b/profunctors.cabal
@@ -35,6 +35,7 @@ library
     comonad             >= 4     && < 6,
     contravariant       >= 1     && < 2,
     distributive        >= 0.4.4 && < 1,
+    semigroups          >= 0.11  && < 0.19,
     tagged              >= 0.4.4 && < 1,
     transformers        >= 0.2   && < 0.6
 

--- a/src/Data/Profunctor/Closed.hs
+++ b/src/Data/Profunctor/Closed.hs
@@ -34,12 +34,12 @@ import Control.Comonad
 import Data.Bifunctor.Product (Product(..))
 import Data.Bifunctor.Tannen (Tannen(..))
 import Data.Distributive
-import Data.Monoid hiding (Product)
 import Data.Profunctor.Adjunction
 import Data.Profunctor.Monad
 import Data.Profunctor.Strong
 import Data.Profunctor.Types
 import Data.Profunctor.Unsafe
+import Data.Semigroup hiding (Product)
 import Data.Tagged
 import Data.Tuple
 import Prelude hiding ((.),id)
@@ -155,9 +155,14 @@ instance (Profunctor p, ArrowPlus p) => Alternative (Closure p a) where
   empty = zeroArrow
   f <|> g = f <+> g
 
-instance (Profunctor p, Arrow p, Monoid b) => Monoid (Closure p a b) where
+instance (Profunctor p, Arrow p, Semigroup b) => Semigroup (Closure p a b) where
+  (<>) = liftA2 (<>)
+
+instance (Profunctor p, Arrow p, Semigroup b, Monoid b) => Monoid (Closure p a b) where
   mempty = pure mempty
-  mappend = liftA2 mappend
+#if !(MIN_VERSION_base(4,11,0))
+  mappend = (<>)
+#endif
 
 -- |
 -- @

--- a/src/Data/Profunctor/Strong.hs
+++ b/src/Data/Profunctor/Strong.hs
@@ -44,11 +44,11 @@ import Data.Bifunctor.Clown (Clown(..))
 import Data.Bifunctor.Product (Product(..))
 import Data.Bifunctor.Tannen (Tannen(..))
 import Data.Functor.Contravariant (Contravariant(..))
-import Data.Monoid hiding (Product)
 import Data.Profunctor.Adjunction
 import Data.Profunctor.Monad
 import Data.Profunctor.Types
 import Data.Profunctor.Unsafe
+import Data.Semigroup hiding (Product)
 import Data.Tagged
 import Data.Tuple
 import Prelude hiding (id,(.))
@@ -226,9 +226,14 @@ instance (Profunctor p, ArrowPlus p) => Alternative (Tambara p a) where
   empty = zeroArrow
   f <|> g = f <+> g
 
+instance ArrowPlus p => Semigroup (Tambara p a b) where
+  f <> g = f <+> g
+
 instance ArrowPlus p => Monoid (Tambara p a b) where
   mempty = zeroArrow
-  mappend f g = f <+> g
+#if !(MIN_VERSION_base(4,11,0))
+  mappend = (<>)
+#endif
 
 -- |
 -- @


### PR DESCRIPTION
In the next version of `base` (4.11), `Semigroup` will be a superclass of `Monoid`. This PR updates `profunctors` accordingly.