### PR TITLE
Add strongMap

### DIFF
--- a/src/Data/Profunctor/Strong.hs
+++ b/src/Data/Profunctor/Strong.hs
@@ -19,6 +19,7 @@ module Data.Profunctor.Strong
   -- * Strength
     Strong(..)
   , uncurry'
+  , strongMap
   , Tambara(..)
   , tambara, untambara
   , Pastro(..)
@@ -94,6 +95,9 @@ class Profunctor p => Strong p where
 uncurry' :: Strong p => p a (b -> c) -> p (a, b) c
 uncurry' = rmap (\(f,x) -> f x) . first'
 {-# INLINE uncurry' #-}
+
+strongMap :: Strong p => (a -> (b -> c)) -> p a b -> p a c
+strongMap f x = dimap (\a -> (a, a)) (\(b, a) -> f a b) (first' x)
 
 instance Strong (->) where
   first' ab ~(a, c) = (ab a, c)


### PR DESCRIPTION
Could we please add the suggestive function `strongMap`.  It exhibits the nature of `Strong` as some sort of higher-order functor.