### PR TITLE
Fix link to second and first in Strong Profunctor laws targeting Arrow

### DIFF
--- a/src/Data/Profunctor/Strong.hs
+++ b/src/Data/Profunctor/Strong.hs
@@ -69,7 +69,7 @@ class Profunctor p => Strong p where
   -- @
   -- 'first'' ≡ 'dimap' 'swap' 'swap' '.' 'second''
   -- 'lmap' 'fst' ≡ 'rmap' 'fst' '.' 'first''
-  -- 'lmap' ('second' f) '.' 'first'' ≡ 'rmap' ('second' f) '.' 'first'
+  -- 'lmap' ('second'' f) '.' 'first'' ≡ 'rmap' ('second'' f) '.' 'first''
   -- 'first'' '.' 'first'' ≡ 'dimap' assoc unassoc '.' 'first'' where
   --   assoc ((a,b),c) = (a,(b,c))
   --   unassoc (a,(b,c)) = ((a,b),c)
@@ -82,7 +82,7 @@ class Profunctor p => Strong p where
   -- @
   -- 'second'' ≡ 'dimap' 'swap' 'swap' '.' 'first''
   -- 'lmap' 'snd' ≡ 'rmap' 'snd' '.' 'second''
-  -- 'lmap' ('first' f) '.' 'second'' ≡ 'rmap' ('first' f) '.' 'second''
+  -- 'lmap' ('first'' f) '.' 'second'' ≡ 'rmap' ('first'' f) '.' 'second''
   -- 'second'' '.' 'second'' ≡ 'dimap' unassoc assoc '.' 'second'' where
   --   assoc ((a,b),c) = (a,(b,c))
   --   unassoc (a,(b,c)) = ((a,b),c)


### PR DESCRIPTION
In Strong Profunctor laws there are references to `first` and `second` from Arrow:
```
lmap fst ≡ rmap fst . first'
lmap (first f) . second' ≡ rmap (first f) . second'
```
but they should link to Strong `first'` and `second'`
```
lmap fst ≡ rmap fst . first'
lmap (first' f) . second' ≡ rmap (first' f) . second'
```