### PR TITLE
[#74] Use QuantifiedConstraints in the Profunctor definition

### DIFF
--- a/src/Data/Profunctor/Cayley.hs
+++ b/src/Data/Profunctor/Cayley.hs
@@ -26,6 +26,9 @@ import Prelude hiding ((.), id)
 -- static arrows
 newtype Cayley f p a b = Cayley { runCayley :: f (p a b) }
 
+instance (Functor f, Functor (p a)) => Functor (Cayley f p a) where
+  fmap f = Cayley . fmap (fmap f) . runCayley
+
 instance Functor f => ProfunctorFunctor (Cayley f) where
   promap f (Cayley p) = Cayley (fmap f p)
 

--- a/src/Data/Profunctor/Closed.hs
+++ b/src/Data/Profunctor/Closed.hs
@@ -29,6 +29,7 @@ import Control.Applicative
 import Control.Arrow
 import Control.Category
 import Control.Comonad
+import Data.Bifunctor (Bifunctor)
 import Data.Bifunctor.Product (Product(..))
 import Data.Bifunctor.Sum (Sum(..))
 import Data.Bifunctor.Tannen (Tannen(..))
@@ -86,7 +87,7 @@ instance (Closed p, Closed q) => Closed (Sum p q) where
   closed (L2 p) = L2 (closed p)
   closed (R2 q) = R2 (closed q)
 
-instance (Functor f, Closed p) => Closed (Tannen f p) where
+instance (Functor f, Bifunctor p, Closed p) => Closed (Tannen f p) where
   closed (Tannen fp) = Tannen (fmap closed fp)
 
 -- instance Monoid r => Closed (Forget r) where
@@ -194,6 +195,9 @@ unclose f p = dimap const ($ ()) $ runClosure $ f p
 
 data Environment p a b where
   Environment :: ((z -> y) -> b) -> p x y -> (a -> z -> x) -> Environment p a b
+
+instance Functor (Environment p a) where
+  fmap f (Environment l m r) = Environment (f . l) m r
 
 instance Profunctor (Environment p) where
   dimap f g (Environment l m r) = Environment (g . l) m (r . f)

--- a/src/Data/Profunctor/Types.hs
+++ b/src/Data/Profunctor/Types.hs
@@ -5,6 +5,11 @@
 
 {-# LANGUAGE Trustworthy #-}
 
+#if __GLASGOW_HASKELL__ >= 806
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE UndecidableInstances #-}
+#endif
+
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015 Edward Kmett,
@@ -147,6 +152,9 @@ instance Monad (Costar f a) where
 -- | Wrap an arrow for use as a 'Profunctor'.
 newtype WrappedArrow p a b = WrapArrow { unwrapArrow :: p a b }
 
+instance Functor (p a) => Functor (WrappedArrow p a) where
+  fmap f (WrapArrow h) = WrapArrow (fmap f h)
+
 instance Category p => Category (WrappedArrow p) where
   WrapArrow f . WrapArrow g = WrapArrow (f . g)
   {-# INLINE (.) #-}
@@ -187,7 +195,11 @@ instance ArrowLoop p => ArrowLoop (WrappedArrow p) where
   loop = WrapArrow . loop . unwrapArrow
   {-# INLINE loop #-}
 
+#if __GLASGOW_HASKELL__ >= 806
+instance (Arrow p, forall a . Functor (p a)) => Profunctor (WrappedArrow p) where
+#else
 instance Arrow p => Profunctor (WrappedArrow p) where
+#endif
   lmap = (^>>)
   {-# INLINE lmap #-}
   rmap = (^<<)

--- a/src/Data/Profunctor/Yoneda.hs
+++ b/src/Data/Profunctor/Yoneda.hs
@@ -156,6 +156,9 @@ returnCoyoneda = Coyoneda id id
 joinCoyoneda :: Coyoneda (Coyoneda p) a b -> Coyoneda p a b
 joinCoyoneda (Coyoneda l r p) = dimap l r p
 
+instance Functor (Coyoneda p a) where
+  fmap f (Coyoneda l r' p) = Coyoneda l (f . r') p
+
 instance Profunctor (Coyoneda p) where
   dimap l r (Coyoneda l' r' p) = Coyoneda (l' . l) (r . r') p
   {-# INLINE dimap #-}


### PR DESCRIPTION
This PR is just proof-of-concept of using [`-XQuantifiedConstraints`](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#quantified-constraints) in the `profunctors` library. The change is motivated by the discussion under corresponding GHC issue:

* https://gitlab.haskell.org/ghc/ghc/issues/16173#ticket

The implementation might not be perfect. Possible improvements I can see:

1. Move all orphan instances to their corresponding libraries.
2. Add `{-# INLINE #-}` pragmas where appropriate.
3. Implement `rmap` as `fmap` where possible.
4. CI fails on ancient GHC versions due to absence of `-XFlexibleContexts` extension.

But I decided to gather feedback first before putting too much effort into this. So feel free to share any thoughts!