### PR TITLE
Fix the type of roam

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+5.5 [???????]
+----------------
+* Change the type of `roam` to make it actually useful.
+
 5.4 [2019.05.10]
 ----------------
 * Add `wander`-like combinator `roam` to `Mapping`.


### PR DESCRIPTION
I wasn't very smart about the way I defined `roam` back in #50.
As @phadej noted in https://github.com/ekmett/profunctors/pull/50#issuecomment-291831127
it's practically unusable. Let's make it much simpler and more useful.
This is a breaking change, but I very much doubt much code will break.