### PR TITLE
Add Choice, Cochoice, Closed, Strong, Costrong instances for Sum

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+next [????.??.??]
+-----------------
+* Add `Choice`, `Cochoice`, `Closed`, `Strong`, and `Costrong` instances for
+  `Data.Bifunctor.Sum`.
+
 5.5 [2019.09.06]
 ----------------
 * Change the type of `roam` to make it actually useful.

--- a/src/Data/Profunctor/Choice.hs
+++ b/src/Data/Profunctor/Choice.hs
@@ -33,8 +33,9 @@ import Control.Category
 import Control.Comonad
 import Data.Bifunctor.Joker (Joker(..))
 import Data.Bifunctor.Product (Product(..))
+import Data.Bifunctor.Sum (Sum(..))
 import Data.Bifunctor.Tannen (Tannen(..))
-import Data.Monoid hiding (Product)
+import Data.Monoid hiding (Product, Sum)
 import Data.Profunctor.Adjunction
 import Data.Profunctor.Monad
 import Data.Profunctor.Strong
@@ -156,6 +157,14 @@ instance (Choice p, Choice q) => Choice (Product p q) where
   left' (Pair p q) = Pair (left' p) (left' q)
   {-# INLINE left' #-}
   right' (Pair p q) = Pair (right' p) (right' q)
+  {-# INLINE right' #-}
+
+instance (Choice p, Choice q) => Choice (Sum p q) where
+  left' (L2 p) = L2 (left' p)
+  left' (R2 q) = R2 (left' q)
+  {-# INLINE left' #-}
+  right' (L2 p) = L2 (right' p)
+  right' (R2 q) = R2 (right' q)
   {-# INLINE right' #-}
 
 instance (Functor f, Choice p) => Choice (Tannen f p) where
@@ -348,6 +357,12 @@ instance (Functor f, Cochoice p) => Cochoice (Tannen f p) where
 instance (Cochoice p, Cochoice q) => Cochoice (Product p q) where
   unleft (Pair p q) = Pair (unleft p) (unleft q)
   unright (Pair p q) = Pair (unright p) (unright q)
+
+instance (Cochoice p, Cochoice q) => Cochoice (Sum p q) where
+  unleft (L2 p) = L2 (unleft p)
+  unleft (R2 q) = R2 (unleft q)
+  unright (L2 p) = L2 (unright p)
+  unright (R2 q) = R2 (unright q)
 
 instance Cochoice (Forget r) where
   unleft (Forget f) = Forget (f . Left)

--- a/src/Data/Profunctor/Closed.hs
+++ b/src/Data/Profunctor/Closed.hs
@@ -30,6 +30,7 @@ import Control.Arrow
 import Control.Category
 import Control.Comonad
 import Data.Bifunctor.Product (Product(..))
+import Data.Bifunctor.Sum (Sum(..))
 import Data.Bifunctor.Tannen (Tannen(..))
 import Data.Coerce (Coercible, coerce)
 import Data.Distributive
@@ -38,7 +39,7 @@ import Data.Profunctor.Monad
 import Data.Profunctor.Strong
 import Data.Profunctor.Types
 import Data.Profunctor.Unsafe
-import Data.Semigroup hiding (Product)
+import Data.Semigroup hiding (Product, Sum)
 import Data.Tagged
 import Data.Tuple
 import Prelude hiding ((.),id)
@@ -80,6 +81,10 @@ instance (Distributive f, Monad f) => Closed (Kleisli f) where
 
 instance (Closed p, Closed q) => Closed (Product p q) where
   closed (Pair p q) = Pair (closed p) (closed q)
+
+instance (Closed p, Closed q) => Closed (Sum p q) where
+  closed (L2 p) = L2 (closed p)
+  closed (R2 q) = R2 (closed q)
 
 instance (Functor f, Closed p) => Closed (Tannen f p) where
   closed (Tannen fp) = Tannen (fmap closed fp)

--- a/src/Data/Profunctor/Strong.hs
+++ b/src/Data/Profunctor/Strong.hs
@@ -39,13 +39,14 @@ import Control.Monad (liftM)
 import Control.Monad.Fix
 import Data.Bifunctor.Clown (Clown(..))
 import Data.Bifunctor.Product (Product(..))
+import Data.Bifunctor.Sum (Sum(..))
 import Data.Bifunctor.Tannen (Tannen(..))
 import Data.Functor.Contravariant (Contravariant(..))
 import Data.Profunctor.Adjunction
 import Data.Profunctor.Monad
 import Data.Profunctor.Types
 import Data.Profunctor.Unsafe
-import Data.Semigroup hiding (Product)
+import Data.Semigroup hiding (Product, Sum)
 import Data.Tagged
 import Data.Tuple
 import Prelude hiding (id,(.))
@@ -144,6 +145,14 @@ instance (Strong p, Strong q) => Strong (Product p q) where
   first' (Pair p q) = Pair (first' p) (first' q)
   {-# INLINE first' #-}
   second' (Pair p q) = Pair (second' p) (second' q)
+  {-# INLINE second' #-}
+
+instance (Strong p, Strong q) => Strong (Sum p q) where
+  first' (L2 p) = L2 (first' p)
+  first' (R2 q) = R2 (first' q)
+  {-# INLINE first' #-}
+  second' (L2 p) = L2 (second' p)
+  second' (R2 q) = R2 (second' q)
   {-# INLINE second' #-}
 
 instance (Functor f, Strong p) => Strong (Tannen f p) where
@@ -377,6 +386,12 @@ instance (Functor f, Costrong p) => Costrong (Tannen f p) where
 instance (Costrong p, Costrong q) => Costrong (Product p q) where
   unfirst (Pair p q) = Pair (unfirst p) (unfirst q)
   unsecond (Pair p q) = Pair (unsecond p) (unsecond q)
+
+instance (Costrong p, Costrong q) => Costrong (Sum p q) where
+  unfirst (L2 p) = L2 (unfirst p)
+  unfirst (R2 q) = R2 (unfirst q)
+  unsecond (L2 p) = L2 (unsecond p)
+  unsecond (R2 q) = R2 (unsecond q)
 
 ----------------------------------------------------------------------------
 -- * Cotambara


### PR DESCRIPTION
This follows up on #63 by adding more instances for `Data.Bifunctor.Sum` to give it parity with `Product`.