### PR TITLE
Achieve instance parity for Cayley and Tannen

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,8 @@
 next [????.??.??]
 -----------------
-* Add `Closed`, `Traversing`, and `Mapping` instances for `Cayley`.
+* Add `Cochoice`, `Costrong`, `Closed`, `Traversing`, and `Mapping` instances
+  for `Cayley`.
+* Add `Mapping` and `Traversing` instances for `Tannen`.
 
 5.5.1 [2019.11.26]
 ------------------

--- a/src/Data/Profunctor/Cayley.hs
+++ b/src/Data/Profunctor/Cayley.hs
@@ -50,9 +50,19 @@ instance (Functor f, Strong p) => Strong (Cayley f p) where
   first'  = Cayley . fmap first' . runCayley
   second' = Cayley . fmap second' . runCayley
 
+instance (Functor f, Costrong p) => Costrong (Cayley f p) where
+  unfirst (Cayley fp) = Cayley (fmap unfirst fp)
+  unsecond (Cayley fp) = Cayley (fmap unsecond fp)
+
 instance (Functor f, Choice p) => Choice (Cayley f p) where
   left'   = Cayley . fmap left' . runCayley
   right'  = Cayley . fmap right' . runCayley
+
+instance (Functor f, Cochoice p) => Cochoice (Cayley f p) where
+  unleft (Cayley fp) = Cayley (fmap unleft fp)
+  {-# INLINE unleft #-}
+  unright (Cayley fp) = Cayley (fmap unright fp)
+  {-# INLINE unright #-}
 
 instance (Functor f, Closed p) => Closed (Cayley f p) where
   closed = Cayley . fmap closed . runCayley

--- a/src/Data/Profunctor/Mapping.hs
+++ b/src/Data/Profunctor/Mapping.hs
@@ -24,6 +24,7 @@ module Data.Profunctor.Mapping
   ) where
 
 import Control.Arrow (Kleisli(..))
+import Data.Bifunctor.Tannen
 import Data.Distributive
 import Data.Functor.Compose
 import Data.Functor.Identity
@@ -89,6 +90,9 @@ genMap abst afb s = fmap (\ab -> abst ab s) (distribute afb)
 instance (Applicative m, Distributive m) => Mapping (Star m) where
   map' (Star f) = Star (collect f)
   roam f = Star #. genMap f .# runStar
+
+instance (Functor f, Mapping p) => Mapping (Tannen f p) where
+  map' = Tannen . fmap map' . runTannen
 
 wanderMapping :: Mapping p => (forall f. Applicative f => (a -> f b) -> s -> f t) -> p a b -> p s t
 wanderMapping f = roam ((runIdentity .) #. f .# (Identity .))

--- a/src/Data/Profunctor/Traversing.hs
+++ b/src/Data/Profunctor/Traversing.hs
@@ -20,6 +20,7 @@ module Data.Profunctor.Traversing
 
 import Control.Applicative
 import Control.Arrow (Kleisli(..))
+import Data.Bifunctor.Tannen
 import Data.Functor.Compose
 import Data.Functor.Identity
 import Data.Orphans ()
@@ -135,6 +136,9 @@ instance Monad m => Traversing (Kleisli m) where
 instance Applicative m => Traversing (Star m) where
   traverse' (Star m) = Star (traverse m)
   wander f (Star amb) = Star (f amb)
+
+instance (Functor f, Traversing p) => Traversing (Tannen f p) where
+  traverse' = Tannen . fmap traverse' . runTannen
 
 newtype CofreeTraversing p a b = CofreeTraversing { runCofreeTraversing :: forall f. Traversable f => p (f a) (f b) }
 


### PR DESCRIPTION
This fixes #83 by adding `Mapping` and `Traversing` instances for `Tannen` (which `Cayley` already has), and by adding `Cochoice` and `Costrong` instances for `Cayley` (which `Tannen` already has).