### PR TITLE
Add the reach function to the Strong class

### DIFF
--- a/src/Data/Profunctor/Cayley.hs
+++ b/src/Data/Profunctor/Cayley.hs
@@ -49,6 +49,7 @@ instance (Functor f, Profunctor p) => Profunctor (Cayley f p) where
 instance (Functor f, Strong p) => Strong (Cayley f p) where
   first'  = Cayley . fmap first' . runCayley
   second' = Cayley . fmap second' . runCayley
+  reach l = Cayley . fmap (reach l) . runCayley
 
 instance (Functor f, Costrong p) => Costrong (Cayley f p) where
   unfirst (Cayley fp) = Cayley (fmap unfirst fp)


### PR DESCRIPTION
This adds the `reach` function to the `Strong` class. It has the following type:

```haskell
reach :: (forall f. Functor f => (a -> f b) -> (s -> f t)) -> p a b -> p s t
```

It has two uses:

- It allows the definition of more efficient `Profunctor`-transformation functions, since it can avoid the construction of tuples demanded by the other functions in this class.

- It acts as a compatibility layer with lenses, without the need for extra dependencies. The first parameter of the function is essentially the definition of a `Lens`. The default definition of 'first'', for example, is:

  ```
  first' = reach _1
  ```

It is mutually defined in terms of `second'`, and `first'` was modified to be defined in terms of `reach`, which means that no existing code should break.

I had to add a `Functor` dependency to the `Kleisli` instance for `Strong` to satify older versions of GHC. I don't know if this is the best solution.