### PR TITLE
Enabled PolyKinds for Cayley, Procompose, Rift, ProfunctorFunctor, Ran, …

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -9,11 +9,12 @@
     - GADTs
     - InstanceSigs
     - MultiParamTypeClasses
+    - PolyKinds
     - RankNTypes
     - ScopedTypeVariables
     - Trustworthy
-    - TypeOperators
     - TypeFamilies
+    - TypeOperators
     - UndecidableInstances
 
 - functions:

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,9 @@
+5.6
+-----
+* Enabled `PolyKinds` extension. The following datatypes now have polymorphic
+  kinds: `(:->)`, `Cayley`, `Procompose`, `Rift`, `ProfunctorFunctor`, `Ran`,
+  `Codensity`, `Prep`, `Coprep`, `Star`, `Costar`, `WrappedArrow`, `Forget`.
+
 5.5.2 [2020.02.13]
 ------------------
 * Add `Cochoice`, `Costrong`, `Closed`, `Traversing`, and `Mapping` instances

--- a/src/Data/Profunctor/Adjunction.hs
+++ b/src/Data/Profunctor/Adjunction.hs
@@ -22,6 +22,8 @@ import Data.Profunctor.Monad
 -- 'unit' '.' 'counit' ≡ 'id'
 -- 'counit' '.' 'unit' ≡ 'id'
 -- @
+
+-- ProfunctorAdjunction :: ((Type -> Type -> Type) -> (Type -> Type -> Type)) -> ((Type -> Type -> Type) -> (Type -> Type -> Type)) -> Constraint
 class (ProfunctorFunctor f, ProfunctorFunctor u) => ProfunctorAdjunction f u | f -> u, u -> f where
   unit   :: Profunctor p => p :-> u (f p)
   counit :: Profunctor p => f (u p) :-> p

--- a/src/Data/Profunctor/Cayley.hs
+++ b/src/Data/Profunctor/Cayley.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE Trustworthy #-}
 -----------------------------------------------------------------------------
@@ -23,7 +24,11 @@ import Data.Profunctor.Traversing
 import Data.Profunctor.Unsafe
 import Prelude hiding ((.), id)
 
--- static arrows
+-- | Static arrows. Lifted by 'Applicative'.
+--
+-- 'Cayley' has a polymorphic kind since profunctors 5.6.
+
+-- Cayley :: (k3 -> Type) -> (k1 -> k2 -> k3) -> (k1 -> k2 -> Type)
 newtype Cayley f p a b = Cayley { runCayley :: f (p a b) }
 
 instance Functor f => ProfunctorFunctor (Cayley f) where

--- a/src/Data/Profunctor/Composition.hs
+++ b/src/Data/Profunctor/Composition.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
 -----------------------------------------------------------------------------
 -- |
@@ -60,6 +61,10 @@ type Iso s t a b = forall p f. (Profunctor p, Functor f) => p a (f b) -> p s (f 
 -- see Dan Piponi's article:
 --
 -- <http://blog.sigfpe.com/2011/07/profunctors-in-haskell.html>
+--
+-- 'Procompose' has a polymorphic kind since profunctors 5.6.
+
+-- Procompose :: (k1 -> k2 -> Type) -> (k3 -> k1 -> Type) -> (k3 -> k2 -> Type)
 data Procompose p q d c where
   Procompose :: p x c -> q d x -> Procompose p q d c
 
@@ -238,6 +243,10 @@ cokleislis = dimap hither (fmap yon) where
 ----------------------------------------------------------------------------
 
 -- | This represents the right Kan lift of a 'Profunctor' @q@ along a 'Profunctor' @p@ in a limited version of the 2-category of Profunctors where the only object is the category Hask, 1-morphisms are profunctors composed and compose with Profunctor composition, and 2-morphisms are just natural transformations.
+--
+-- 'Rift' has a polymorphic kind since profunctors 5.6.
+
+-- Rift :: (k3 -> k2 -> Type) -> (k1 -> k2 -> Type) -> (k1 -> k3 -> Type)
 newtype Rift p q a b = Rift { runRift :: forall x. p b x -> q a x }
 
 instance ProfunctorFunctor (Rift p) where

--- a/src/Data/Profunctor/Monad.hs
+++ b/src/Data/Profunctor/Monad.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeOperators #-}
 -----------------------------------------------------------------------------
@@ -19,6 +20,9 @@ import Data.Bifunctor.Product
 import Data.Bifunctor.Sum
 import Data.Profunctor.Types
 
+-- | 'ProfunctorFunctor' has a polymorphic kind since profunctors 5.6.
+
+-- ProfunctorFunctor :: ((Type -> Type -> Type) -> (k1 -> k2 -> Type)) -> Constraint
 class ProfunctorFunctor t where
   -- | Laws:
   --
@@ -26,7 +30,7 @@ class ProfunctorFunctor t where
   -- 'promap' f '.' 'promap' g ≡ 'promap' (f '.' g)
   -- 'promap' 'id' ≡ 'id'
   -- @
-  promap    :: Profunctor p => (p :-> q) -> t p :-> t q
+  promap :: Profunctor p => (p :-> q) -> t p :-> t q
 
 instance Functor f => ProfunctorFunctor (Tannen f) where
   promap f (Tannen g) = Tannen (fmap f g)
@@ -46,6 +50,8 @@ instance ProfunctorFunctor (Sum p) where
 -- 'projoin' '.' 'promap' 'proreturn' ≡ 'id'
 -- 'projoin' '.' 'projoin' ≡ 'projoin' '.' 'promap' 'projoin'
 -- @
+
+-- ProfunctorMonad :: ((Type -> Type -> Type) -> (Type -> Type -> Type)) -> Constraint
 class ProfunctorFunctor t => ProfunctorMonad t where
   proreturn :: Profunctor p => p :-> t p
   projoin   :: Profunctor p => t (t p) :-> t p
@@ -71,6 +77,8 @@ instance ProfunctorMonad (Sum p) where
 -- 'promap' 'proextract' '.' 'produplicate' ≡ 'id'
 -- 'produplicate' '.' 'produplicate' ≡ 'promap' 'produplicate' '.' 'produplicate'
 -- @
+
+-- ProfunctorComonad :: ((Type -> Type -> Type) -> (Type -> Type -> Type)) -> Constraint
 class ProfunctorFunctor t => ProfunctorComonad t where
   proextract :: Profunctor p => t p :-> p
   produplicate :: Profunctor p => t p :-> t (t p)

--- a/src/Data/Profunctor/Ran.hs
+++ b/src/Data/Profunctor/Ran.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -33,6 +34,10 @@ import Prelude hiding (id,(.))
 --------------------------------------------------------------------------------
 
 -- | This represents the right Kan extension of a 'Profunctor' @q@ along a 'Profunctor' @p@ in a limited version of the 2-category of Profunctors where the only object is the category Hask, 1-morphisms are profunctors composed and compose with Profunctor composition, and 2-morphisms are just natural transformations.
+--
+-- 'Ran' has a polymorphic kind since profunctors 5.6.
+
+-- Ran :: (k1 -> k2 -> Type) -> (k1 -> k3 -> Type) -> (k2 -> k3 -> Type)
 newtype Ran p q a b = Ran { runRan :: forall x. p x a -> q x b }
 
 instance ProfunctorFunctor (Ran p) where
@@ -89,6 +94,10 @@ uncurryRan f (Procompose p q) = runRan (f p) q
 --------------------------------------------------------------------------------
 
 -- | This represents the right Kan extension of a 'Profunctor' @p@ along itself. This provides a generalization of the \"difference list\" trick to profunctors.
+--
+-- 'Codensity' has a polymorphic kind since profunctors 5.6.
+
+-- Codensity :: (k1 -> k2 -> Type) -> (k2 -> k2 -> Type)
 newtype Codensity p a b = Codensity { runCodensity :: forall x. p x a -> p x b }
 
 instance Profunctor p => Profunctor (Codensity p) where

--- a/src/Data/Profunctor/Rep.hs
+++ b/src/Data/Profunctor/Rep.hs
@@ -1,11 +1,12 @@
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE UndecidableInstances #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Profunctor.Rep
@@ -178,6 +179,10 @@ cotabulated = dimap cotabulate (fmap cosieve)
 --
 -- This gives rise to a monad in @Prof@, @('Star'.'Prep')@, and
 -- a comonad in @[Hask,Hask]@ @('Prep'.'Star')@
+--
+-- 'Prep' has a polymorphic kind since profunctors 5.6.
+
+-- Prep :: (Type -> k -> Type) -> (k -> Type)
 data Prep p a where
   Prep :: x -> p x a -> Prep p a
 
@@ -210,6 +215,9 @@ prepCounit (Prep x p) = runStar p x
 -- * Coprep
 --------------------------------------------------------------------------------
 
+-- | 'Prep' has a polymorphic kind since profunctors 5.6.
+
+-- Coprep :: (k -> Type -> Type) -> (k -> Type)
 newtype Coprep p a = Coprep { runCoprep :: forall r. p a r -> r }
 
 instance Profunctor p => Functor (Coprep p) where

--- a/src/Data/Profunctor/Types.hs
+++ b/src/Data/Profunctor/Types.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
 
 {-# LANGUAGE Trustworthy #-}
 
@@ -46,6 +47,10 @@ import Data.Traversable
 import Prelude hiding (id,(.))
 
 infixr 0 :->
+
+-- | ':->' has a polymorphic kind since profunctors 5.6.
+  
+-- (:->) :: forall k1 k2. (k1 -> k2 -> Type) -> (k1 -> k2 -> Type) -> Type
 type p :-> q = forall a b. p a b -> q a b
 
 ------------------------------------------------------------------------------
@@ -53,6 +58,10 @@ type p :-> q = forall a b. p a b -> q a b
 ------------------------------------------------------------------------------
 
 -- | Lift a 'Functor' into a 'Profunctor' (forwards).
+--
+-- 'Star' has a polymorphic kind since profunctors 5.6.
+
+-- Star :: (k -> Type) -> (Type -> k -> Type)
 newtype Star f d c = Star { runStar :: d -> f c }
 
 instance Functor f => Profunctor (Star f) where
@@ -108,6 +117,10 @@ instance Contravariant f => Contravariant (Star f a) where
 ------------------------------------------------------------------------------
 
 -- | Lift a 'Functor' into a 'Profunctor' (backwards).
+--
+-- 'Costar' has a polymorphic kind since profunctors 5.6.
+
+-- Costar :: (k -> Type) -> k -> Type -> Type
 newtype Costar f d c = Costar { runCostar :: f d -> c }
 
 instance Functor f => Profunctor (Costar f) where
@@ -145,6 +158,10 @@ instance Monad (Costar f a) where
 ------------------------------------------------------------------------------
 
 -- | Wrap an arrow for use as a 'Profunctor'.
+--
+-- 'WrappedArrow' has a polymorphic kind since profunctors 5.6.
+
+-- WrappedArrow :: (k1 -> k2 -> Type) -> (k1 -> k2 -> Type)
 newtype WrappedArrow p a b = WrapArrow { unwrapArrow :: p a b }
 
 instance Category p => Category (WrappedArrow p) where
@@ -198,6 +215,9 @@ instance Arrow p => Profunctor (WrappedArrow p) where
 -- Forget
 ------------------------------------------------------------------------------
 
+-- | 'Forget' has a polymorphic kind since profunctors 5.6.
+
+-- Forget :: Type -> Type -> k -> Type
 newtype Forget r a b = Forget { runForget :: a -> r }
 
 instance Profunctor (Forget r) where


### PR DESCRIPTION
Enabled PolyKinds for Cayley, Procompose, Rift, ProfunctorFunctor, Ran, Codensity, Prep, Coprep, Star, Costar, WrappedArrow, Forget are now polykinded.

I also added some kind signatures in comments until we can use `StandaloneKindSignatures`. Let me know and I'll remove it. The reason for this is a polymorphic `Cayley`, I wanted to define `Data.Monoid.Ap` in terms of it.