### PR TITLE
Eta-expand some definitions to work under simplified subsumption.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -52,7 +52,10 @@
 
 - ignore:
     name: Eta reduce
-    within: Data.Profunctor.Mapping
+    within:
+    - Data.Profunctor.Mapping
+    - Data.Profunctor.Choice
+    - Data.Profunctor.Strong
 
 - ignore:
     name: "Use tuple-section"

--- a/src/Data/Profunctor/Choice.hs
+++ b/src/Data/Profunctor/Choice.hs
@@ -215,7 +215,7 @@ instance Profunctor p => Profunctor (TambaraSum p) where
   {-# INLINE dimap #-}
 
 instance Profunctor p => Choice (TambaraSum p) where
-  left' = runTambaraSum . produplicate
+  left' p = runTambaraSum $ produplicate p
   {-# INLINE left' #-}
 
 instance Category p => Category (TambaraSum p) where
@@ -405,7 +405,7 @@ instance Functor (CotambaraSum p a) where
 -- 'uncotambaraSum' '.' 'cotambaraSum' ≡ 'id'
 -- @
 cotambaraSum :: Cochoice p => (p :-> q) -> p :-> CotambaraSum q
-cotambaraSum = CotambaraSum
+cotambaraSum f = CotambaraSum f
 
 -- |
 -- @

--- a/src/Data/Profunctor/Closed.hs
+++ b/src/Data/Profunctor/Closed.hs
@@ -120,11 +120,11 @@ instance ProfunctorFunctor Closure where
   promap f (Closure p) = Closure (f p)
 
 instance ProfunctorComonad Closure where
-  proextract = dimap const ($ ()) . runClosure
+  proextract p = dimap const ($ ()) $ runClosure p
   produplicate (Closure p) = Closure $ Closure $ dimap uncurry curry p
 
 instance Profunctor p => Closed (Closure p) where
-  closed = runClosure . produplicate
+  closed p = runClosure $ produplicate p
 
 instance Strong p => Strong (Closure p) where
   first' (Closure p) = Closure $ dimap hither yon $ first' p

--- a/src/Data/Profunctor/Strong.hs
+++ b/src/Data/Profunctor/Strong.hs
@@ -185,7 +185,7 @@ instance ProfunctorComonad Tambara where
     yon    ~(x,~(y,z)) = ((x,y),z)
 
 instance Profunctor p => Strong (Tambara p) where
-  first' = runTambara . produplicate
+  first' p = runTambara $ produplicate p
   {-# INLINE first' #-}
 
 instance Category p => Category (Tambara p) where
@@ -425,7 +425,7 @@ instance Functor (Cotambara p a) where
 -- 'uncotambara' '.' 'cotambara' ≡ 'id'
 -- @
 cotambara :: Costrong p => (p :-> q) -> p :-> Cotambara q
-cotambara = Cotambara
+cotambara f = Cotambara f
 
 -- |
 -- @


### PR DESCRIPTION
Due to simplified subsumption (https://github.com/ghc-proposals/ghc-proposals/blob/wip/spj-deep-skol/proposals/0000-simplify-subsumption.md), several function definitions have to be eta-expanded to type check under GHC 9.