### PR TITLE
Add Functor instances for Coyoneda, {Co}PastroSum, Environment, {Co}Pastro, and Free{Mapping,Traversing}

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+next [????.??.??]
+-----------------
+* Add `Functor` instances for `PastroSum`, `CopastroSum`, `Environment`,
+  `FreeMapping`, `Pastro`, `Copastro`, `FreeTraversing`, and `Coyoneda`.
+
 5.6 [2020.10.01]
 ----------------
 * Enable the `PolyKinds` extension. The following datatypes now have

--- a/src/Data/Profunctor/Choice.hs
+++ b/src/Data/Profunctor/Choice.hs
@@ -254,6 +254,9 @@ fromEither = either id id
 data PastroSum p a b where
   PastroSum :: (Either y z -> b) -> p x y -> (a -> Either x z) -> PastroSum p a b
 
+instance Functor (PastroSum p a) where
+  fmap f (PastroSum l m r) = PastroSum (f . l) m r
+
 instance Profunctor (PastroSum p) where
   dimap f g (PastroSum l m r) = PastroSum (g . l) m (r . f)
   lmap f (PastroSum l m r) = PastroSum l m (r . f)
@@ -423,6 +426,9 @@ uncotambaraSum f p = proextract (f p)
 --
 -- 'CopastroSum' freely constructs costrength with respect to 'Either' (aka 'Choice')
 newtype CopastroSum p a b = CopastroSum { runCopastroSum :: forall r. Cochoice r => (forall x y. p x y -> r x y) -> r a b }
+
+instance Functor (CopastroSum p a) where
+  fmap f (CopastroSum h) = CopastroSum $ \ n -> rmap f (h n)
 
 instance Profunctor (CopastroSum p) where
   dimap f g (CopastroSum h) = CopastroSum $ \ n -> dimap f g (h n)

--- a/src/Data/Profunctor/Closed.hs
+++ b/src/Data/Profunctor/Closed.hs
@@ -195,6 +195,9 @@ unclose f p = dimap const ($ ()) $ runClosure $ f p
 data Environment p a b where
   Environment :: ((z -> y) -> b) -> p x y -> (a -> z -> x) -> Environment p a b
 
+instance Functor (Environment p a) where
+  fmap f (Environment l m r) = Environment (f . l) m r
+
 instance Profunctor (Environment p) where
   dimap f g (Environment l m r) = Environment (g . l) m (r . f)
   lmap f (Environment l m r) = Environment l m (r . f)

--- a/src/Data/Profunctor/Mapping.hs
+++ b/src/Data/Profunctor/Mapping.hs
@@ -141,6 +141,9 @@ instance ProfunctorComonad CofreeMapping where
 data FreeMapping p a b where
   FreeMapping :: Functor f => (f y -> b) -> p x y -> (a -> f x) -> FreeMapping p a b
 
+instance Functor (FreeMapping p a) where
+  fmap f (FreeMapping l m r) = FreeMapping (f . l) m r
+
 instance Profunctor (FreeMapping p) where
   lmap f (FreeMapping l m r) = FreeMapping l m (r . f)
   rmap g (FreeMapping l m r) = FreeMapping (g . l) m r

--- a/src/Data/Profunctor/Strong.hs
+++ b/src/Data/Profunctor/Strong.hs
@@ -272,6 +272,9 @@ untambara f p = dimap (\a -> (a,())) fst $ runTambara $ f p
 data Pastro p a b where
   Pastro :: ((y, z) -> b) -> p x y -> (a -> (x, z)) -> Pastro p a b
 
+instance Functor (Pastro p a) where
+  fmap f (Pastro l m r) = Pastro (f . l) m r
+
 instance Profunctor (Pastro p) where
   dimap f g (Pastro l m r) = Pastro (g . l) m (r . f)
   lmap f (Pastro l m r) = Pastro l m (r . f)
@@ -443,6 +446,9 @@ uncotambara f p = proextract (f p)
 --
 -- Copastro freely constructs costrength
 newtype Copastro p a b = Copastro { runCopastro :: forall r. Costrong r => (forall x y. p x y -> r x y) -> r a b }
+
+instance Functor (Copastro p a) where
+  fmap f (Copastro h) = Copastro $ \ n -> rmap f (h n)
 
 instance Profunctor (Copastro p) where
   dimap f g (Copastro h) = Copastro $ \ n -> dimap f g (h n)

--- a/src/Data/Profunctor/Traversing.hs
+++ b/src/Data/Profunctor/Traversing.hs
@@ -168,6 +168,9 @@ instance ProfunctorComonad CofreeTraversing where
 data FreeTraversing p a b where
   FreeTraversing :: Traversable f => (f y -> b) -> p x y -> (a -> f x) -> FreeTraversing p a b
 
+instance Functor (FreeTraversing p a) where
+  fmap f (FreeTraversing l m r) = FreeTraversing (f . l) m r
+
 instance Profunctor (FreeTraversing p) where
   lmap f (FreeTraversing l m r) = FreeTraversing l m (r . f)
   rmap g (FreeTraversing l m r) = FreeTraversing (g . l) m r

--- a/src/Data/Profunctor/Yoneda.hs
+++ b/src/Data/Profunctor/Yoneda.hs
@@ -155,6 +155,9 @@ returnCoyoneda = Coyoneda id id
 joinCoyoneda :: Coyoneda (Coyoneda p) a b -> Coyoneda p a b
 joinCoyoneda (Coyoneda l r p) = dimap l r p
 
+instance Functor (Coyoneda p a) where
+  fmap f (Coyoneda l r' p) = Coyoneda l (f . r') p
+
 instance Profunctor (Coyoneda p) where
   dimap l r (Coyoneda l' r' p) = Coyoneda (l' . l) (r . r') p
   {-# INLINE dimap #-}


### PR DESCRIPTION
These are quite straightforward to define, and they will likely be useful in a future where `Profunctor` has a quantified `Functor` superclass, such as what is being proposed in #70. In fact, this patch is simply a subset of that one, authored by ChShersh.

There are other data types that could potentially have `Functor` instances, but the exact shapes of these instances is yet unclear. (See the ongoing discussion in #70.) For now, I've opted to stick with the most uncontroversial instances that do not use any flexible or quantified constraints.

This supersedes #92, which requests the `Coyoneda` instance in particular. To ensure that these instances are forward compatible with a proposal like #70, I have rewritten the proposed instance in #92 to avoid the use of `fmap = rmap`, as it is quite likely that #70 will introduce a new `Profunctor` law that `rmap = fmap`.