### PR TITLE
Add Monoid/Semigroup for Forget

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+5.6.2 [unreleased]
+------------------
+* Add `Semigroup` and `Monoid` instances for `Forget`
+
 5.6.1 [2020.12.31]
 ------------------
 * Add `Functor` instances for `PastroSum`, `CopastroSum`, `Environment`,

--- a/profunctors.cabal
+++ b/profunctors.cabal
@@ -1,6 +1,6 @@
 name:          profunctors
 category:      Control, Categories
-version:       5.6.1
+version:       5.6.2
 license:       BSD3
 cabal-version: >= 1.10
 license-file:  LICENSE

--- a/src/Data/Profunctor/Types.hs
+++ b/src/Data/Profunctor/Types.hs
@@ -41,7 +41,8 @@ import Data.Coerce (Coercible, coerce)
 import Data.Distributive
 import Data.Foldable
 import Data.Functor.Contravariant
-import Data.Monoid hiding (Product)
+import Data.Semigroup hiding (Product)
+import Data.Monoid hiding (Product, (<>))
 import Data.Profunctor.Unsafe
 import Data.Traversable
 import Prelude hiding (id,(.))
@@ -243,3 +244,21 @@ instance Traversable (Forget r a) where
 instance Contravariant (Forget r a) where
   contramap _ (Forget k) = Forget k
   {-# INLINE contramap #-}
+
+-- | Via @Semigroup r => (a -> r)@
+--
+-- @since 5.6.2
+instance Semigroup r => Semigroup (Forget r a b) where
+  Forget f <> Forget g = Forget (f <> g)
+  {-# INLINE (<>) #-}
+
+-- | Via @Monoid r => (a -> r)@
+--
+-- @since 5.6.2
+instance Monoid r => Monoid (Forget r a b) where
+  mempty = Forget mempty
+  {-# INLINE mempty #-}
+#if !(MIN_VERSION_base(4,11,0))
+  mappend (Forget f) (Forget g) = Forget (mappend f g)
+  {-# INLINE mappend #-}
+#endif


### PR DESCRIPTION
This hopefully isn't too controversial since this is the natural Monoid for the underlying function; in fact you could `deriving via (a -> r)` if you wanted.

Adding this allows us to smash together Folds with profunctor optics; e.g. you get `(x ^.. to f <> to g) == [f x, g x]` which is nice, and this instance just generally does the Right Thing™ when working with Forget 😄 

Let me know if there's anything else you need 👍 

Thanks for maintaining this library; it's taught me a lot over the years!