### PR TITLE
Add arrow-related instances

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -12,7 +12,36 @@
 * Re-export Data.Bifunctor.Functor's (:->) rather than supply our own
   so the two definitions do not conflict.
 * Added fixpoints of ProfunctorFunctors.
-* Add `instance Monoid r => Applicative (Forget r a)`.
+* Added `instance Monoid r => Applicative (Forget r a)`.
+* Added a number of (co)strength instances:
+  * `MonadFix f => Costrong (Star f)`
+  * `Strong p => Strong (TambaraSum p)`
+  * `Costrong p => Costrong (TambaraSum p)`
+  * `Strong p => Strong (PastroSum p)`
+  * `(Strong p, Costrong q) => Costrong (Rift p q)`
+  * `(Choice p, Cochoice q) => Cochoice (Rift p q)`
+  * `(Strong p, Costrong q) => Costrong (Ran p q)`
+  * `(Choice p, Cochoice q) => Cochoice (Ran p q)`
+  * `(Strong p, Costrong p) => Costrong (Codensity p)`
+  * `(Choice p, Cochoice p) => Cochoice (Codensity p)`
+  * `(Profunctor p, Strong q) => Strong (Day p q)`
+  * `(Choice p, Choice q) => Choice (Day p q)`
+* Added `Arrow`, `ArrowChoice`, and `ArrowLoop` instances to all types that have appropriate (co)strength.
+* Added `ArrowPlus p => ArrowPlus (WrappedArrow p)`
+* Added other arrow isntances:
+  * `MonadPlus f => ArrowZero (Star f)`
+  * `MonadPlus f => ArrowPlus (Star f)`
+  * `Monad f => ArrowApply (Star f)`
+  * `(ArrowZero p, Profunctor p) => ArrowZero (CofreeTraversing p)`
+  * `(ArrowPlus p, Profunctor p) => ArrowPlus (CofreeTraversing p)`
+  * `ArrowZero p => ArrowZero (TambaraSum p)`
+  * `ArrowPlus p => ArrowPlus (TambaraSum p)`
+  * `(ArrowZero p, Profunctor p) => ArrowZero (Yoneda p)`
+  * `(ArrowPlus p, Profunctor p) => ArrowPlus (Yoneda p)`
+  * `(ArrowApply p, Profunctor p) => ArrowApply (Yoneda p)`
+  * `(ArrowZero p, Profunctor p) => ArrowZero (Coyoneda p)`
+  * `(ArrowPlus p, Profunctor p) => ArrowPlus (Coyoneda p)`
+  * `(ArrowApply p, Profunctor p) => ArrowApply (Coyoneda p)`
 
 5.6.2 [2021.02.17]
 ------------------

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -28,7 +28,7 @@
   * `(Choice p, Choice q) => Choice (Day p q)`
 * Added `Arrow`, `ArrowChoice`, and `ArrowLoop` instances to all types that have appropriate (co)strength.
 * Added `ArrowPlus p => ArrowPlus (WrappedArrow p)`
-* Added other arrow isntances:
+* Added other arrow instances:
   * `MonadPlus f => ArrowZero (Star f)`
   * `MonadPlus f => ArrowPlus (Star f)`
   * `Monad f => ArrowApply (Star f)`

--- a/src/Data/Profunctor/Composition.hs
+++ b/src/Data/Profunctor/Composition.hs
@@ -252,6 +252,18 @@ instance p ~ q => Category (Rift p q) where
   Rift f . Rift g = Rift (g . f)
   {-# INLINE (.) #-}
 
+instance (Strong p, Costrong q) => Costrong (Rift p q) where
+  unfirst (Rift h) = Rift $ unfirst . h . first'
+  {-# INLINE unfirst #-}
+  unsecond (Rift h) = Rift $ unsecond . h . second'
+  {-# INLINE unsecond #-}
+
+instance (Choice p, Cochoice q) => Cochoice (Rift p q) where
+  unleft (Rift h) = Rift $ unleft . h . left'
+  {-# INLINE unleft #-}
+  unright (Rift h) = Rift $ unright . h . right'
+  {-# INLINE unright #-}
+
 -- | The 2-morphism that defines a left Kan lift.
 --
 -- Note: When @p@ is right adjoint to @'Rift' p (->)@ then 'decomposeRift' is the 'counit' of the adjunction.

--- a/src/Data/Profunctor/Ran.hs
+++ b/src/Data/Profunctor/Ran.hs
@@ -76,6 +76,18 @@ instance p ~ q => Category (Ran p q) where
   Ran f . Ran g = Ran (f . g)
   {-# INLINE (.) #-}
 
+instance (Strong p, Costrong q) => Costrong (Ran p q) where
+  unfirst (Ran h) = Ran $ unfirst . h . first'
+  {-# INLINE unfirst #-}
+  unsecond (Ran h) = Ran $ unsecond . h . second'
+  {-# INLINE unsecond #-}
+
+instance (Choice p, Cochoice q) => Cochoice (Ran p q) where
+  unleft (Ran h) = Ran $ unleft . h . left'
+  {-# INLINE unleft #-}
+  unright (Ran h) = Ran $ unright . h . right'
+  {-# INLINE unright #-}
+
 -- | The 2-morphism that defines a right Kan extension.
 --
 -- Note: When @q@ is left adjoint to @'Ran' q (->)@ then 'decomposeRan' is the 'counit' of the adjunction.
@@ -129,6 +141,18 @@ instance Category (Codensity p) where
   {-# INLINE id #-}
   Codensity f . Codensity g = Codensity (f . g)
   {-# INLINE (.) #-}
+
+instance (Strong p, Costrong p) => Costrong (Codensity p) where
+  unfirst (Codensity h) = Codensity $ unfirst . h . first'
+  {-# INLINE unfirst #-}
+  unsecond (Codensity h) = Codensity $ unsecond . h . second'
+  {-# INLINE unsecond #-}
+
+instance (Choice p, Cochoice p) => Cochoice (Codensity p) where
+  unleft (Codensity h) = Codensity $ unleft . h . left'
+  {-# INLINE unleft #-}
+  unright (Codensity h) = Codensity $ unright . h . right'
+  {-# INLINE unright #-}
 
 decomposeCodensity :: Procompose (Codensity p) p a b -> p a b
 decomposeCodensity (Procompose (Codensity pp) p) = pp p

--- a/src/Data/Profunctor/Strong.hs
+++ b/src/Data/Profunctor/Strong.hs
@@ -380,6 +380,12 @@ instance Costrong (->) where
   unfirst f a = b where (b, d) = f (a, d)
   unsecond f a = b where (d, b) = f (d, a)
 
+instance MonadFix f => Costrong (Star f) where
+  unfirst (Star f) = Star $ \x -> fst <$> mfix (\ ~(_, y) -> f (x, y))
+  {-# INLINE unfirst #-}
+  unsecond (Star f) = Star $ \x -> snd <$> mfix (\ ~(y, _) -> f (y, x))
+  {-# INLINE unsecond #-}
+
 instance Functor f => Costrong (Costar f) where
   unfirst (Costar f) = Costar f'
     where f' fa = b where (b, d) = f ((\a -> (a, d)) <$> fa)
@@ -390,6 +396,7 @@ instance Costrong Tagged where
   unfirst (Tagged bd) = Tagged (fst bd)
   unsecond (Tagged db) = Tagged (snd db)
 
+-- | 'ArrowLoop' is a 'Costrong' 'Arrow'.
 instance ArrowLoop p => Costrong (WrappedArrow p) where
   unfirst (WrapArrow k) = WrapArrow (loop k)
 

--- a/src/Data/Profunctor/Types.hs
+++ b/src/Data/Profunctor/Types.hs
@@ -34,6 +34,7 @@ import Control.Arrow
 import Control.Category
 import Control.Comonad
 import Control.Monad (MonadPlus(..), (>=>))
+import Control.Monad.Fix
 import Data.Bifunctor.Functor ((:->))
 import Data.Coerce (Coercible, coerce)
 import Data.Foldable
@@ -93,6 +94,40 @@ instance Monad f => Category (Star f) where
   id = Star return
   Star f . Star g = Star $ g >=> f
 
+instance Monad f => Arrow (Star f) where
+  arr f = Star (pure . f)
+  {-# INLINE arr #-}
+  first (Star f) = Star $ \ ~(a, c) -> (\b' -> (b', c)) <$> f a
+  {-# INLINE first #-}
+  second (Star f) = Star $ \ ~(c, a) -> (,) c <$> f a
+  {-# INLINE second #-}
+  Star f *** Star g = Star $ \ ~(x, y) -> liftA2 (flip (,)) (g y) (f x)
+  {-# INLINE (***) #-}
+  Star f &&& Star g = Star $ \ x -> liftA2 (flip (,)) (g x) (f x)
+  {-# INLINE (&&&) #-}
+
+instance MonadPlus f => ArrowZero (Star f) where
+  zeroArrow = Star $ \_ -> mzero
+  {-# INLINE zeroArrow #-}
+
+instance MonadPlus f => ArrowPlus (Star f) where
+  Star f <+> Star g = Star $ \x -> mplus (f x) (g x)
+  {-# INLINE (<+>) #-}
+
+instance Monad f => ArrowChoice (Star f) where
+  left (Star f) = Star $ either (fmap Left . f) (pure . Right)
+  {-# INLINE left #-}
+  right (Star f) = Star $ either (pure . Left) (fmap Right . f)
+  {-# INLINE right #-}
+
+instance Monad f => ArrowApply (Star f) where
+  app = Star $ \ ~(Star f, x) -> f x
+  {-# INLINE app #-}
+
+instance MonadFix f => ArrowLoop (Star f) where
+  loop (Star f) = Star $ \x -> fst <$> mfix (\ ~(_, y) -> f (x, y))
+  {-# INLINE loop #-}
+
 instance Contravariant f => Contravariant (Star f a) where
   contramap f (Star g) = Star (contramap f . g)
   {-# INLINE contramap #-}
@@ -136,11 +171,26 @@ instance Monad (Costar f a) where
   return = pure
   Costar m >>= f = Costar $ \ x -> runCostar (f (m x)) x
 
+instance Comonad f => Category (Costar f) where
+  id = Costar extract
+  {-# INLINE id #-}
+  Costar f . Costar g = Costar (f =<= g)
+  {-# INLINE (.) #-}
+
 ------------------------------------------------------------------------------
 -- Wrapped Profunctors
 ------------------------------------------------------------------------------
 
--- | Wrap an arrow for use as a 'Profunctor'.
+-- |
+-- - 'Arrow' is equivalent to 'Category'
+--   && t'Data.Profunctor.Strong.Strong'.
+-- - 'ArrowChoice' is equivalent to 'Category'
+--   && t'Data.Profunctor.Strong.Strong' && t'Data.Profunctor.Choice.Choice'.
+-- - 'ArrowLoop' is equivalent to 'Category'
+--   && t'Data.Profunctor.Strong.Strong' && t'Data.Profunctor.Strong.Costrong'.
+--
+-- This newtype allows 'Profunctor' classes to be used with types that only
+-- implement @base@'s arrow classes.
 --
 -- 'WrappedArrow' has a polymorphic kind since @5.6@.
 
@@ -172,6 +222,10 @@ instance Arrow p => Arrow (WrappedArrow p) where
 instance ArrowZero p => ArrowZero (WrappedArrow p) where
   zeroArrow = WrapArrow zeroArrow
   {-# INLINE zeroArrow #-}
+
+instance ArrowPlus p => ArrowPlus (WrappedArrow p) where
+  WrapArrow p <+> WrapArrow q = WrapArrow (p <+> q)
+  {-# INLINE (<+>) #-}
 
 instance ArrowChoice p => ArrowChoice (WrappedArrow p) where
   left = WrapArrow . left . unwrapArrow

--- a/src/Data/Profunctor/Types.hs
+++ b/src/Data/Profunctor/Types.hs
@@ -181,16 +181,15 @@ instance Comonad f => Category (Costar f) where
 -- Wrapped Profunctors
 ------------------------------------------------------------------------------
 
--- |
+-- | This newtype allows 'Profunctor' classes to be used with types that only
+-- implement @base@'s arrow classes.
+--
 -- - 'Arrow' is equivalent to 'Category'
 --   && t'Data.Profunctor.Strong.Strong'.
 -- - 'ArrowChoice' is equivalent to 'Category'
 --   && t'Data.Profunctor.Strong.Strong' && t'Data.Profunctor.Choice.Choice'.
 -- - 'ArrowLoop' is equivalent to 'Category'
 --   && t'Data.Profunctor.Strong.Strong' && t'Data.Profunctor.Strong.Costrong'.
---
--- This newtype allows 'Profunctor' classes to be used with types that only
--- implement @base@'s arrow classes.
 --
 -- 'WrappedArrow' has a polymorphic kind since @5.6@.
 


### PR DESCRIPTION
We know that:
- `Arrow` = `Strong` + `Category`,
- `ArrowChoice` = `Choice` + `Strong` + `Category`
- `ArrowLoop` = `Costrong` + `Strong` + `Category`

The `WrappedArrow` class allows using `profunctors` classes with types that only implement `base` arrows instances. However since `profunctors` depends on `base`, the expectation is that anything that is a Strong Category should also be an Arrow, etc, else you can't use arrow syntax!

Hence I've added the following instances:

- `ArrowPlus p => ArrowPlus (WrappedArrow p)` -- there was `ArrowZero`, but not `ArrowPlus` for some reason
- `Star`
  - `MonadFix f => Costrong (Star f)` -- derived from `Kleisli`
  - `Monad f => Arrow (Star f)` -- derived from its strength
  - `MonadPlus f => ArrowZero (Star f)` -- using `Alternative` (we have a `Monad` superclass constraint anyway, hence `MonadPlus`)
  - `MonadPlus f => ArrowPlus (Star f)` -- using `MonadPlus`
  - `Monad f => ArrowChoice (Star f)` -- derived from its choice
  - `Monad f => ArrowApply (Star f)` -- derived from `Kleisli`
  - `MonadFix f => ArrowLoop (Star f)` -- derived from the aforementioned costrength
- `Costar`
  - `Comonad f => Category (Costar f)` -- derived from `Cokleisli`
- `CofreeTraversing`
  - `Category p => Category (CofreeTraversing p)` -- things of the form `forall x. p (x ⊗ a) (x ⊗ b)` (end comonads) naturally form a category
  - `(Category p, Profunctor p) => Arrow (CofreeTraversing p)` -- derived from its strength
  - `(ArrowZero p, Profunctor p) => ArrowZero (CofreeTraversing p)` -- natural for "end comonads"
  - `(ArrowPlus p, Profunctor p) => ArrowPlus (CofreeTraversing p)` -- natural for "end comonads" (the arrows are always in parallel)
  - `(Category p, Profunctor p) => ArrowChoice (CofreeTraversing p)` -- derived from its choice
- `TambaraSum`
  - `Strong p => Strong (TambaraSum p)` -- looks asymmetric, but shouldn't be, given lawful `Strong p`
  - `Costrong p => Costrong (TambaraSum p)` -- same benign asymmetry
  - `Arrow p => Arrow (TambaraSum p)` -- derived from aforementioned strength
  - `Arrow p => ArrowChoice (TambaraSum p)` -- derived from aforementioned choice
  - `ArrowZero p => ArrowZero (TambaraSum p)` -- natural for "end comonads"
  - `ArrowPlus p => ArrowPlus (TambaraSum p)` -- natural for "end comonads"
- `PastroSum`
  - `Strong p => Strong (PastroSum p)` -- checks out
- `Yoneda` -- degenerates when `Profunctor p`, hence much like its other instances we just extract and proreturn
  - `(Arrow p, Profunctor p) => Arrow (Yoneda p)` -- derived from its strength
  - `(ArrowZero p, Profunctor p) => ArrowZero (Yoneda p)`
  - `(ArrowPlus p, Profunctor p) => ArrowPlus (Yoneda p)`
  - `(ArrowChoice p, Profunctor p) => ArrowChoice (Yoneda p)` -- derived from its choice
  - `(ArrowApply p, Profunctor p) => ArrowApply (Yoneda p)`
  - `(ArrowLoop p, Profunctor p) => ArrowLoop (Yoneda p)` -- derived from its costrength
- `Coyoneda` -- likewise we just return and proextract
  - `(Arrow p, Profunctor p) => Arrow (Coyoneda p)` -- derived from its strength
  - `(ArrowZero p, Profunctor p) => ArrowZero (Coyoneda p)`
  - `(ArrowPlus p, Profunctor p) => ArrowPlus (Coyoneda p)`
  - `(ArrowChoice p, Profunctor p) => ArrowChoice (Coyoneda p)` -- derived from its choice
  - `(ArrowApply p, Profunctor p) => ArrowApply (Coyoneda p)`
  - `(ArrowLoop p, Profunctor p) => ArrowLoop (Coyoneda p)` -- derived from its costrength
- `Rift`
  - `(Strong p, Costrong q) => Costrong (Rift p q)` -- checks out
  - `(Choice p, Cochoice q) => Cochoice (Rift p q)` -- checks out
- `Ran`
  - `(Strong p, Costrong q) => Costrong (Ran p q)` -- same as `Rift`
  - `(Choice p, Cochoice q) => Cochoice (Ran p q)` -- same as `Rift`
- `Codensity`
  - `(Strong p, Costrong p) => Costrong (Codensity p)` -- derived from `Ran p p`
  - `(Choice p, Cochoice p) => Cochoice (Codensity p)` -- derived from `Ran p p`
- `Day`
  - `(Profunctor p, Strong q) => Strong (Day p q)` -- this one could alternatively be defined using `p`'s strength, but I figured it should target the same argument as does `ProfunctorMonad`, also `swapped` is right there.
  - `(Choice p, Choice q) => Choice (Day p q)`

Things like `Category (Pastro p)` require `Strong p` at which point `Pastro p <-> p` and if you want an arrow you can just extract, so I've decided to not bother with that. Likewise with `Category (FreeTraversing p)`.