### PR TITLE
Make the Kleisli Profunctor constraint be Functor.

### DIFF
--- a/src/Data/Profunctor/Unsafe.hs
+++ b/src/Data/Profunctor/Unsafe.hs
@@ -32,7 +32,6 @@ module Data.Profunctor.Unsafe
 import Control.Arrow
 import Control.Category
 import Control.Comonad (Cokleisli(..))
-import Control.Monad (liftM)
 import Data.Bifunctor.Biff (Biff(..))
 import Data.Bifunctor.Clown (Clown(..))
 import Data.Bifunctor.Joker (Joker(..))
@@ -185,12 +184,12 @@ instance Profunctor Tagged where
   Tagged s .# _ = Tagged s
   {-# INLINE (.#) #-}
 
-instance Monad m => Profunctor (Kleisli m) where
-  dimap f g (Kleisli h) = Kleisli (liftM g . h . f)
+instance Functor m => Profunctor (Kleisli m) where
+  dimap f g (Kleisli h) = Kleisli (fmap g <$> h . f)
   {-# INLINE dimap #-}
   lmap k (Kleisli f) = Kleisli (f . k)
   {-# INLINE lmap #-}
-  rmap k (Kleisli f) = Kleisli (liftM k . f)
+  rmap k (Kleisli f) = Kleisli (fmap k <$> f)
   {-# INLINE rmap #-}
   -- We cannot safely overload (#.) because we didn't provide the 'Monad'.
   (.#) pbc _ = coerce pbc


### PR DESCRIPTION
This reduces the constraint on the Kleisli Profunctor implementatin from Monad to Functor.  In addition to following the general principle that constraints should be as minimal as possible, I have a specific use case that requires this.  I have a situation where I have a productor profunctor adapator (created by Data.Profunctor.Product.TH's makeAdapatorAndInterfaceInferrable, and I want to create a default bitraverse implementation, using the Kleisli profunctor.  Except that bitraverse only gives me Applicative m, not Monad.